### PR TITLE
Adds twitter widget aside to Oscailte theme

### DIFF
--- a/source/_includes/asides/twitter.html
+++ b/source/_includes/asides/twitter.html
@@ -1,0 +1,18 @@
+{% if site.social.twitter %}
+<section id="latest-tweets" class="aside-module grid__item one-whole lap-one-half">
+  <h1 class="title delta">
+  Latest Tweets
+  {% if site.twitter_show_profile_link %}
+  <small class="pull-right">
+    <a class="btn" href="//twitter.com/{{ site.social.twitter }}" title="@{{site.social.twitter}} on Twitter" target="_blank">
+      <i class="icon-external-link"></i>
+    </a>
+  </small>
+  {% endif %}
+</h1>
+  <ul id="tweets" class="divided">
+    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/{{ site.social.twitter }}"  data-widget-id="{{ site.twitter_widget_id }}"  data-link-color="#1863a1" data-tweet-limit="{{ site.twitter_tweet_count }}" data-chrome="noheader nofooter transparent noscrollbar">Tweets by @{{ site.social.twitter }}</a>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+  </ul>
+</section>
+{% endif %}


### PR DESCRIPTION
The default octopress theme removed the "Latest Tweets" aside after
Twitter updated their API to v1.1 and removed support for unauthenticated
API calls. Twitter does, however, offer a widget that integrates well
with blogging platforms, including Octopress.

Jmac discusses integrating the twitter widget with Octopress  on his blog:
http://blog.jmac.org/blog/2013/03/30/putting-twitter-back-into-octopress/

This commit integrates Jmac's suggestion by:
- creating twitter.html in source/_includes/asides as discussed by Jmac
- adding a check for the site.social.twitter variable to display the aside
- utilizing the variables in _config.yml including:
  - site.social.twitter (string)
  - site.twitter_tweet_count (int)
  - site.twitter_show_profile_link (bool) (NEW)
  - site.twitter.widget_id (int) (NEW)
- adding a link button to the header, to match the style of other asides
  in Oscailte (e.g. Github)
- adding classes to section, h1, and ul to match the style of other asides
  in Oscailte

Users will have to add the NEW variables to _config.yml, which means creating
a new timeline widget on Twitter and obtaining a twitter widget id:
https://twitter.com/settings/widgets/new
