### PR TITLE
Added $double--slash-color variable.

### DIFF
--- a/sass/oscailte/_variables.scss
+++ b/sass/oscailte/_variables.scss
@@ -75,6 +75,7 @@ $homepage--usp-color: $typography--color !default;
 // --------------
 $post--title-color: $color--primary !default;
 $post--title-font:  $typography--serif !default;
+$double--slash-color: $post--title-color !default;
 
 
 // SYNTAX VARIABLES (Code Highlighting)


### PR DESCRIPTION
It was added to give more control over the look and feel of the blog, so the "//" part can be customized as the user wishes. By default it uses the "$post--title-color" variable for consistency.